### PR TITLE
Set line endings check to automatic

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,6 @@
 {
   "semi": false,
   "singleQuote": true,
-  "printWidth": 120
+  "printWidth": 120,
+  "endOfLine": "auto",
 }


### PR DESCRIPTION
Change the end of line setting in the linter to 'automatic' to prevent errors between linux and windows machines (because of ␍ line endings).