### PR TITLE
Pre-render activities to avoid unnecessary dynamic loading

### DIFF
--- a/components/Activities.vue
+++ b/components/Activities.vue
@@ -60,22 +60,17 @@
 </template>
 
 <script>
-import axios from 'axios'
 import dayjs from 'dayjs'
 import Zondicon from 'vue-zondicons'
+import activities from '~/static/activities.json'
 
 export default {
   props: ['title'],
   components: { Zondicon },
   data() {
     return {
-      activities: []
+      activities: activities.data.sort((a, b) => a.start_time.localeCompare(b.start_time)).splice(0, 3)
     }
-  },
-  mounted() {
-    axios.get('/activities.json').then(response => {
-      this.activities = response.data.data.sort((a, b) => a.start_time.localeCompare(b.start_time)).splice(0, 3)
-    })
   },
   methods: {
     formatDate(date) {

--- a/components/Activities.vue
+++ b/components/Activities.vue
@@ -7,10 +7,18 @@
     </div>
     <div class="md:flex justify-center">
       <div v-for="activity in activities" :key="activity.name" class="bg-white rounded shadow flex-1 mx-2 mt-4">
-        <a :href="'https://www.facebook.com/events/' + activity.id" target="_blank">
-          <img :src="activity.cover.source" class="rounded-t" />
-          <div class="p-4 pt-3">
-            <h3 class="text-pink-400 text-xl font-bold">{{ activity.name }}</h3>
+        <a
+          :href="'https://www.facebook.com/events/' + activity.id"
+          target="_blank"
+          class="flex flex-col justify-between h-full"
+        >
+          <div>
+            <img :src="activity.cover.source" class="rounded-t" />
+            <div class="px-4 pt-3">
+              <h3 class="text-pink-400 text-xl font-bold">{{ activity.name }}</h3>
+            </div>
+          </div>
+          <div class="px-4 pb-4">
             <span class="text-gray-500">{{ formatDate(activity.start_time) }}</span>
           </div>
         </a>

--- a/components/Activities.vue
+++ b/components/Activities.vue
@@ -61,6 +61,7 @@
 
 <script>
 import dayjs from 'dayjs'
+import 'dayjs/locale/nl'
 import Zondicon from 'vue-zondicons'
 import activities from '~/static/activities.json'
 
@@ -75,6 +76,7 @@ export default {
   methods: {
     formatDate(date) {
       if (this.$i18n.locale === 'nl') {
+        dayjs.locale('nl')
         return dayjs(date).format('D MMMM YYYY [om] HH:mm uur')
       }
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "nuxt build",
     "start": "nuxt start",
     "generate": "nuxt generate",
-    "production": "nuxt generate; node retrieve_events.js",
+    "production": "node retrieve_events.js; nuxt generate",
     "lint": "eslint --ext .js,.vue --ignore-path .gitignore .",
     "precommit": "npm run lint"
   },

--- a/retrieve_events.js
+++ b/retrieve_events.js
@@ -8,5 +8,5 @@ axios
       process.env.FACEBOOK_PAGE_ACCESS_TOKEN
   )
   .then(response => {
-    fs.writeFile('dist/activities.json', JSON.stringify(response.data), 'utf8', () => {})
+    fs.writeFile('static/activities.json', JSON.stringify(response.data), 'utf8', () => {})
   })


### PR DESCRIPTION
The activities were previously fetched dynamically, but this was unnecessary since the events are only refreshed during a build.