### PR TITLE
Fix gradient for webkit browsers

### DIFF
--- a/pages/barbuddy.vue
+++ b/pages/barbuddy.vue
@@ -198,6 +198,6 @@ export default {
 }
 
 .white-gradient {
-  background-image: linear-gradient(to right, rgba(255, 0, 0, 0), rgba(255, 255, 255, 1));
+  background-image: linear-gradient(to right, rgba(255, 255, 255, 0), rgba(255, 255, 255, 1));
 }
 </style>


### PR DESCRIPTION
Fixes the gradient in the new barbuddies page for iOS/macOS Safari.
![image](https://user-images.githubusercontent.com/15815208/67769814-667ad180-fa55-11e9-8bba-cdb881ec866e.png)
-->
![image](https://user-images.githubusercontent.com/15815208/67769837-6f6ba300-fa55-11e9-882e-e74391513809.png)
