### PR TITLE
Fix warnings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,6 +19,8 @@ module.exports = {
   ],
   // add your custom rules here
   rules: {
-    'max-len': ["error", { "code": 120 }]
+    'max-len': ["error", { "code": 120 }],
+    'vue/require-prop-types': "off",
+    'vue/require-default-prop': "off"
   }
 }

--- a/app/router.scrollBehavior.js
+++ b/app/router.scrollBehavior.js
@@ -1,0 +1,30 @@
+export default async function (to, from, savedPosition) {
+  if (savedPosition) {
+    return savedPosition
+  }
+
+  const findEl = (hash, x) => {
+    return (
+      document.querySelector(hash) ||
+      new Promise((resolve, reject) => {
+        if (x > 50) {
+          return resolve()
+        }
+        setTimeout(() => {
+          resolve(findEl(hash, ++x || 1))
+        }, 100)
+      })
+    )
+  }
+
+  if (to.hash) {
+    const el = await findEl(to.hash)
+    if ('scrollBehavior' in document.documentElement.style) {
+      return window.scrollTo({ top: el.offsetTop, behavior: 'smooth' })
+    } else {
+      return window.scrollTo(0, el.offsetTop)
+    }
+  }
+
+  return { x: 0, y: 0 }
+}

--- a/app/router.scrollBehavior.js
+++ b/app/router.scrollBehavior.js
@@ -1,4 +1,4 @@
-export default async function (to, from, savedPosition) {
+export default async function(to, from, savedPosition) {
   if (savedPosition) {
     return savedPosition
   }

--- a/components/Activities.vue
+++ b/components/Activities.vue
@@ -77,8 +77,8 @@ import Zondicon from 'vue-zondicons'
 import activitiesFile from '~/static/activities.json'
 
 export default {
-  props: ['title'],
   components: { Zondicon },
+  props: ['title'],
   data() {
     return {
       activities: JSON.parse(JSON.stringify(activitiesFile))

--- a/components/Footer.vue
+++ b/components/Footer.vue
@@ -29,13 +29,13 @@
             <div class="rounded-full w-8 h-8 p-2 bg-white text-gray-700">
               <Zondicon icon="envelope" class="fill-current w-4" />
             </div>
-            <div class="ml-3" v-html="contactEmail" />
+            <div v-html="contactEmail" class="ml-3" />
           </div>
           <div class="flex items-center">
             <div class="rounded-full w-8 h-8 p-2 bg-white text-gray-700">
               <Zondicon icon="map" class="fill-current w-4" />
             </div>
-            <div class="ml-3" v-html="contactAddress" />
+            <div v-html="contactAddress" class="ml-3" />
           </div>
         </div>
       </div>
@@ -87,16 +87,6 @@ import GitHubIcon from '@/assets/images/social/github.svg'
 import YouTubeIcon from '@/assets/images/social/youtube.svg'
 
 export default {
-  props: [
-    'left-title',
-    'right-title',
-    'link-title',
-    'link-destination',
-    'board-image',
-    'contact-email',
-    'contact-address',
-    'dwh-description'
-  ],
   components: {
     Zondicon,
     DWHLogo,
@@ -104,6 +94,16 @@ export default {
     FacebookIcon,
     GitHubIcon,
     YouTubeIcon
-  }
+  },
+  props: [
+    'leftTitle',
+    'rightTitle',
+    'linkTitle',
+    'linkDestination',
+    'boardImage',
+    'contactEmail',
+    'contactAddress',
+    'dwhDescription'
+  ]
 }
 </script>

--- a/components/Header.vue
+++ b/components/Header.vue
@@ -61,13 +61,13 @@ import NLFlag from '@/assets/images/flags/nl.svg'
 import GBFlag from '@/assets/images/flags/gb.svg'
 
 export default {
-  props: ['small'],
   components: {
     OutsiteLogo,
     DWHLogo,
     NLFlag,
     GBFlag
   },
+  props: ['small'],
   mounted() {
     window.addEventListener('load', () => {
       document.getElementById('headervid').play()

--- a/components/JoinOptions.vue
+++ b/components/JoinOptions.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="container px-4 mx-auto pt-8 pb-12">
     <div class="text-center">
-      <h1 class="text-white font-medium text-5xl" v-html="title"></h1>
+      <h1 v-html="title" class="text-white font-medium text-5xl"></h1>
     </div>
     <div class="md:flex justify-center">
       <div class="bg-white rounded shadow p-8 flex-1 mx-2 flex flex-col justify-between mt-4">
@@ -52,6 +52,7 @@
 import Zondicon from 'vue-zondicons'
 
 export default {
+  components: { Zondicon },
   props: [
     'title',
     'leftIcon',
@@ -62,7 +63,6 @@ export default {
     'rightButtonText',
     'leftUrl',
     'rightUrl'
-  ],
-  components: { Zondicon }
+  ]
 }
 </script>

--- a/components/JoinWhatsApp.vue
+++ b/components/JoinWhatsApp.vue
@@ -51,7 +51,7 @@
 
           <div v-if="state == 'success'" class="text-left">
             <span class="block leading-tight">{{ $t('forms.success.heading') }}</span>
-            <span class="block text-base" v-text="$t('forms.success.whatsapp')" />
+            <span v-text="$t('forms.success.whatsapp')" class="block text-base" />
           </div>
         </div>
         <button
@@ -89,11 +89,11 @@ import submitFormToFirebase from '~/modules/firebase-submitter'
 import WhatsAppLogo from '@/assets/images/whatsapp_logo.svg'
 
 export default {
-  props: ['button-text', 'button-target'],
   components: {
     WhatsAppLogo,
     Zondicon
   },
+  props: ['buttonText', 'buttonTarget'],
   data() {
     return {
       state: 'cta',

--- a/components/OWeeSchedule.vue
+++ b/components/OWeeSchedule.vue
@@ -53,8 +53,8 @@ import schedule from '~/assets/owee_schedule.csv'
 import OWeeLogo from '@/assets/images/owee_2019_logo.svg'
 
 export default {
-  props: ['title'],
   components: { OWeeLogo },
+  props: ['title'],
   data() {
     return {
       activities: schedule.map(row => {

--- a/components/Video.vue
+++ b/components/Video.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="container px-4 mx-auto pt-8 pb-16">
-    <h2 class="text-center text-pink-500 font-medium text-5xl mb-4" v-html="title"></h2>
+    <h2 v-html="title" class="text-center text-pink-500 font-medium text-5xl mb-4"></h2>
     <div class="mx-auto bg-black rounded shadow-xl md:w-2/3">
       <div class="embed-responsive aspect-ratio-16/9">
         <iframe
-          class="embed-responsive-item rounded"
           :src="url"
+          class="embed-responsive-item rounded"
           frameborder="0"
           allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
           allowfullscreen

--- a/lang/nl.js
+++ b/lang/nl.js
@@ -40,8 +40,8 @@ export default {
     kmg: {
       title: 'Kennismakingsgroepen (KMG)',
       description: `Twee keer per jaar organiseert Outsite de KMG. In een kennismakingsgroep maak je onder begeleiding
-        van twee ervaren leden kennis met de vereniging maar vooral ook met elkaar. Op negen donderdagavonden deel je met
-        elkaar je coming-out verhalen (als je dat wil), je gaat langs een gay feest en nog veel meer!`,
+        van twee ervaren leden kennis met de vereniging maar vooral ook met elkaar. Op negen donderdagavonden deel je
+        met elkaar je coming-out verhalen (als je dat wil), je gaat langs een gay feest en nog veel meer!`,
       action: 'Doe mee aan de KMG',
       sign_up: 'Aanmelden voor de KMG',
       next: `<strong>De KennisMakingsGroep van februari gaat binnenkort van start</strong>, meld je nu aan!

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -14,15 +14,15 @@
         :link-title="$t('confidential_counsellor.title')"
         :link-destination="localePath('confidential-counsellor')"
         :right-title="$t('footer.rightTitle')"
+        :dwh-description="$t('footer.dwhDescription')"
         contact-email="bestuur@outsite.nl"
         contact-address="Lange Geer 22<br />2611PV Delft"
-        :dwh-description="$t('footer.dwhDescription')"
       >
         <template v-slot:board-members>
-          <BoardMember name="Niv Bharos" :role="$t('footer.board.president')" email="voorzitter@outsite.nl" />
-          <BoardMember name="Ivo Brands" :role="$t('footer.board.secretary')" email="secretaris@outsite.nl" />
-          <BoardMember name="Bouke Stoelinga" :role="$t('footer.board.treasurer')" email="penningmeester@outsite.nl" />
-          <BoardMember name="Eva Pelk" :role="$t('footer.board.external_affairs')" email="extern@outsite.nl" />
+          <BoardMember :role="$t('footer.board.president')" name="Niv Bharos" email="voorzitter@outsite.nl" />
+          <BoardMember :role="$t('footer.board.secretary')" name="Ivo Brands" email="secretaris@outsite.nl" />
+          <BoardMember :role="$t('footer.board.treasurer')" name="Bouke Stoelinga" email="penningmeester@outsite.nl" />
+          <BoardMember :role="$t('footer.board.external_affairs')" name="Eva Pelk" email="extern@outsite.nl" />
         </template>
       </Footer>
     </footer>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -58,7 +58,10 @@ export default {
   ],
 
   i18n: {
-    locales: [{ code: 'nl', iso: 'nl-NL', file: 'nl.js' }, { code: 'en', iso: 'en-US', file: 'en.js' }],
+    locales: [
+      { code: 'nl', iso: 'nl-NL', file: 'nl.js' },
+      { code: 'en', iso: 'en-US', file: 'en.js' }
+    ],
     defaultLocale: 'nl',
     langDir: 'lang/',
     lazy: true,

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -108,38 +108,6 @@ export default {
       })
     }
   },
-  router: {
-    scrollBehavior: async (to, from, savedPosition) => {
-      if (savedPosition) {
-        return savedPosition
-      }
-
-      const findEl = (hash, x) => {
-        return (
-          document.querySelector(hash) ||
-          new Promise((resolve, reject) => {
-            if (x > 50) {
-              return resolve()
-            }
-            setTimeout(() => {
-              resolve(findEl(hash, ++x || 1))
-            }, 100)
-          })
-        )
-      }
-
-      if (to.hash) {
-        const el = await findEl(to.hash)
-        if ('scrollBehavior' in document.documentElement.style) {
-          return window.scrollTo({ top: el.offsetTop, behavior: 'smooth' })
-        } else {
-          return window.scrollTo(0, el.offsetTop)
-        }
-      }
-
-      return { x: 0, y: 0 }
-    }
-  },
 
   netlify: {
     redirects: createRedirects().concat([

--- a/pages/barbuddy.vue
+++ b/pages/barbuddy.vue
@@ -10,14 +10,14 @@
 
     <section class="container mx-auto pb-4 text-xl md:text-2xl leading-normal text-gray-800">
       <div class="md:w-2/3 mx-4 md:mx-auto">
-        <p class="mt-8 mb-4 md:mt-0 md:mb-12" v-html="$t('ways_to_join.bar_buddy.description')" />
+        <p v-html="$t('ways_to_join.bar_buddy.description')" class="mt-8 mb-4 md:mt-0 md:mb-12" />
       </div>
     </section>
 
     <section class="bg-pink-200">
       <div class="container px-4 mx-auto pt-8 pb-12">
         <div class="text-center">
-          <h1 class="text-white font-medium text-5xl" v-html="$t('ways_to_join.bar_buddy.barbuddies_title')" />
+          <h1 v-html="$t('ways_to_join.bar_buddy.barbuddies_title')" class="text-white font-medium text-5xl" />
         </div>
         <div class="md:flex flex-wrap -mx-2 mt-2">
           <div v-for="buddy in barbuddies" :key="buddy.name" class="md:w-1/2 p-2">
@@ -31,7 +31,7 @@
                     {{ buddy.name }}
                   </h2>
                 </div>
-                <button class="button-pink flex items-center hidden md:flex" @click="meetWith(buddy)">
+                <button @click="meetWith(buddy)" class="button-pink flex items-center hidden md:flex">
                   {{ $t('ways_to_join.bar_buddy.meet_up_with') }} {{ buddy.name }}
                   <Zondicon icon="arrow-thin-right" class="ml-2 w-4 fill-current" />
                 </button>
@@ -39,13 +39,13 @@
               <p :class="['text-lg relative', buddy.readMore ? 'pb-8' : 'clamp-lines']">
                 <span class="absolute bottom-0 right-0 flex">
                   <span class="w-32 block white-gradient" />
-                  <a class="text-pink-400 bg-white cursor-pointer" @click="readMore(buddy)">
+                  <a @click="readMore(buddy)" class="text-pink-400 bg-white cursor-pointer">
                     {{ $t('ways_to_join.bar_buddy.' + (buddy.readMore ? 'read_less' : 'read_more')) }}
                   </a>
                 </span>
                 {{ buddy.bio }}
               </p>
-              <button class="button-pink flex items-center mt-4 flex md:hidden" @click="meetWith(buddy)">
+              <button @click="meetWith(buddy)" class="button-pink flex items-center mt-4 flex md:hidden">
                 {{ $t('ways_to_join.bar_buddy.meet_up_with') }} {{ buddy.name }}
                 <Zondicon icon="arrow-thin-right" class="ml-2 w-4 fill-current" />
               </button>
@@ -73,10 +73,10 @@
             </div>
           </div>
         </div>
-        <form v-if="formStatus !== 'finished'" class="md:w-2/3 mx-4 md:mx-auto mt-8 md:my-12" @submit="submit">
+        <form v-if="formStatus !== 'finished'" @submit="submit" class="md:w-2/3 mx-4 md:mx-auto mt-8 md:my-12">
           <p class="form-element">
             <label class="required">{{ $t('forms.label.name') }}</label>
-            <input v-model="form.name" type="text" :placeholder="$t('forms.placeholder.name')" required />
+            <input v-model="form.name" :placeholder="$t('forms.placeholder.name')" type="text" required />
           </p>
           <p class="form-element">
             <label class="required">{{ $t('forms.label.language') }}</label>
@@ -95,15 +95,15 @@
           </p>
           <p class="form-element">
             <label class="required">{{ $t('forms.label.email') }}</label>
-            <input v-model="form.email" type="email" :placeholder="$t('forms.placeholder.email')" required />
+            <input v-model="form.email" :placeholder="$t('forms.placeholder.email')" type="email" required />
           </p>
           <p class="form-element">
             <label>{{ $t('forms.label.phone_number') }}</label>
-            <input v-model="form.phoneNumber" type="text" :placeholder="$t('forms.placeholder.phone_number')" />
+            <input v-model="form.phoneNumber" :placeholder="$t('forms.placeholder.phone_number')" type="text" />
           </p>
           <p class="form-element">
             <label>{{ $t('forms.label.pronouns') }}</label>
-            <input v-model="form.pronouns" type="text" :placeholder="$t('forms.placeholder.pronouns')" />
+            <input v-model="form.pronouns" :placeholder="$t('forms.placeholder.pronouns')" type="text" />
           </p>
           <p class="form-element">
             <label class="required">{{ $t('forms.label.barbuddy') }}</label>
@@ -112,7 +112,7 @@
               {{ $t('forms.label.languages.no_preference') }}
             </label>
             <label v-for="buddy in barbuddies" :key="buddy.name" class="radio">
-              <input v-model="form.barbuddy" type="radio" :value="buddy.name" :checked="buddy.selected" />
+              <input v-model="form.barbuddy" :value="buddy.name" :checked="buddy.selected" type="radio" />
               {{ buddy.name }}
             </label>
           </p>

--- a/pages/confidential-counsellor.vue
+++ b/pages/confidential-counsellor.vue
@@ -10,7 +10,7 @@
 
     <section class="container mx-auto pb-4 text-xl md:text-2xl leading-normal text-gray-800">
       <div class="md:w-2/3 mx-4 md:mx-auto">
-        <p class="mt-8 mb-4 md:mt-0 md:mb-12" v-html="$t('confidential_counsellor.description')" />
+        <p v-html="$t('confidential_counsellor.description')" class="mt-8 mb-4 md:mt-0 md:mb-12" />
       </div>
     </section>
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -26,7 +26,7 @@
     <section class="introduction overflow-x-hidden">
       <div class="container mx-auto pt-12 pb-24 md:flex">
         <div class="flex-1 md:w-1/2 px-4">
-          <p class="text-lg md:text-xl leading-relaxed text-gray-800" v-html="$t('description.text')"></p>
+          <p v-html="$t('description.text')" class="text-lg md:text-xl leading-relaxed text-gray-800"></p>
           <div
             class="
               rounded shadow-xl bg-pink-400 text-lg md:text-xl text-white my-12 md:mt-10 md:mb-24 p-4 relative
@@ -41,7 +41,7 @@
             >
               <Zondicon icon="explore" class="fill-current" />
             </div>
-            <div class="mt-6 md:mt-0 md:ml-4" v-html="$t('description.invitation')" />
+            <div v-html="$t('description.invitation')" class="mt-6 md:mt-0 md:ml-4" />
           </div>
         </div>
         <div class="flex-1 md:w-1/2 overflow-hidden md:overflow-visible relative">
@@ -57,14 +57,14 @@
     <section id="join-outsite" class="bg-pink-200 bg-hero-falling-triangles">
       <JoinOptions
         :title="$t('ways_to_join.title')"
-        left-icon="user-group"
         :left-title="$t('ways_to_join.kmg.title')"
         :left-button-text="$t('ways_to_join.kmg.action')"
         :left-url="localePath('kmg')"
-        right-icon="beverage"
         :right-title="$t('ways_to_join.bar_buddy.title')"
         :right-button-text="$t('ways_to_join.bar_buddy.action')"
         :right-url="localePath('barbuddy')"
+        left-icon="user-group"
+        right-icon="beverage"
       >
         <template v-slot:left>
           {{ $t('ways_to_join.kmg.description') }}

--- a/pages/kmg.vue
+++ b/pages/kmg.vue
@@ -11,7 +11,7 @@
     <section class="container mx-auto pb-4 text-xl md:text-2xl leading-normal text-gray-800">
       <div class="md:w-2/3 mx-4 md:mx-auto">
         <p class="my-8 md:mt-0 md:mb-12">{{ $t('ways_to_join.kmg.description') }}</p>
-        <p class="mb-4 md:my-12" v-html="$t('ways_to_join.kmg.next')"></p>
+        <p v-html="$t('ways_to_join.kmg.next')" class="mb-4 md:my-12"></p>
       </div>
     </section>
 
@@ -35,32 +35,32 @@
           </p>
           <p class="form-element">
             <label class="required">{{ $t('forms.label.name') }}</label>
-            <input type="text" name="name" :placeholder="$t('forms.placeholder.name')" required />
+            <input :placeholder="$t('forms.placeholder.name')" type="text" name="name" required />
           </p>
           <p class="form-element">
             <label class="required">{{ $t('forms.label.email') }}</label>
-            <input type="email" name="email" :placeholder="$t('forms.placeholder.email')" required />
+            <input :placeholder="$t('forms.placeholder.email')" type="email" name="email" required />
           </p>
           <p class="form-element">
             <label class="required">{{ $t('forms.label.date_of_birth') }}</label>
-            <input type="text" name="dateofbirth" :placeholder="$t('forms.placeholder.date_of_birth')" required />
+            <input :placeholder="$t('forms.placeholder.date_of_birth')" type="text" name="dateofbirth" required />
           </p>
           <p class="form-element">
             <label>{{ $t('forms.label.phone_number') }}</label>
-            <input type="text" name="phonenumber" :placeholder="$t('forms.placeholder.phone_number')" />
+            <input :placeholder="$t('forms.placeholder.phone_number')" type="text" name="phonenumber" />
           </p>
           <p class="form-element">
             <label>{{ $t('forms.label.residence') }}</label>
-            <input type="text" name="city" :placeholder="$t('forms.placeholder.residence')" />
+            <input :placeholder="$t('forms.placeholder.residence')" type="text" name="city" />
           </p>
           <p class="form-element">
             <label class="required">{{ $t('forms.label.language') }}</label>
             <label class="radio">
-              <input type="radio" name="language" value="dutch" :checked="$i18n.locale == 'nl'" />
+              <input :checked="$i18n.locale == 'nl'" type="radio" name="language" value="dutch" />
               {{ $t('forms.label.languages.dutch') }}
             </label>
             <label class="radio">
-              <input type="radio" name="language" value="english" :checked="$i18n.locale == 'en'" />
+              <input :checked="$i18n.locale == 'en'" type="radio" name="language" value="english" />
               {{ $t('forms.label.languages.english') }}
             </label>
             <label class="radio">
@@ -70,11 +70,11 @@
           </p>
           <p class="form-element">
             <label>{{ $t('forms.label.pronouns') }}</label>
-            <input type="text" name="pronouns" :placeholder="$t('forms.placeholder.pronouns')" />
+            <input :placeholder="$t('forms.placeholder.pronouns')" type="text" name="pronouns" />
           </p>
           <p class="form-element">
             <label>{{ $t('forms.label.remarks') }}</label>
-            <textarea name="remarks" :placeholder="$t('forms.placeholder.remarks')"></textarea>
+            <textarea :placeholder="$t('forms.placeholder.remarks')" name="remarks"></textarea>
           </p>
           <p class="mt-8 md:my-8 text-right">
             <button type="submit" class="button-pink">


### PR DESCRIPTION
(Essentially a copy of the same in dwhdelft.nl)
Applied the --fix flag of ESLint (and the Vue component). Disabled two linting rules for props that would make the code a lot longer to fix and don't add much since basically all of the props are strings. This fixes all of the many linting warnings.

Secondarily, fixed a warning about deprecated use of router.scrollBehavior.

Lastly, shortened a line that went over 120 characters.